### PR TITLE
Fixed missing removal of emulated UID

### DIFF
--- a/src/ToypadChallenge/Toypad.Launcher/Emulator/EmulatorForm.cs
+++ b/src/ToypadChallenge/Toypad.Launcher/Emulator/EmulatorForm.cs
@@ -263,6 +263,7 @@ namespace Toypad.Launcher.Emulator
             {
                 case Pad.None:
                     tagFlow.Controls.Remove(tag);
+                    _toypad?.RemoveEmulatedTag(tag.Uid);
                     break;
                 case Pad.Left:
                     leftFlow.Controls.Remove(tag);
@@ -284,6 +285,7 @@ namespace Toypad.Launcher.Emulator
             if (target is null)
             {
                 _knownUids.Remove(BitConverter.ToString(tag.Uid));
+                _toypad?.RemoveEmulatedTag(tag.Uid);
                 tag.Dispose();
                 return;
             }


### PR DESCRIPTION
Previous:
When restarting Toypad with an loaded EmulatorTag, removing this Tag in the emulator wouldn't remove it from the Toypad.
Fixed by adding remove calls.

@tomwendel please add issue tab to github repo to enable bug reports, etc. ;)